### PR TITLE
Herokuデプロイ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+group :production do
+  gem 'rails_12factor'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -229,6 +234,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4)
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails_12factor
   rubocop
   sass-rails (~> 5)
   selenium-webdriver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
+    end
+  end
+
 end


### PR DESCRIPTION
## What
- Herokuへのデプロイ
- ユーザー認証導入

## why
- アプリケーションを公開する準備のためにHeroku での各種設定をする。
  - Heroku上へのアプリケーション作成,MySQL,masterkey,環境変数
- 実装をこまめに本番環境でも確認するため
- パスワードとユーザーIDを知る人しかアクセスできないように、ユーザー認証を導入する。

## points
- ユーザー認証の、パスワード、IDはgitからpushは絶対にしない。